### PR TITLE
[PR]  Add Azure documentation.

### DIFF
--- a/plausible/README.md
+++ b/plausible/README.md
@@ -1652,7 +1652,7 @@ they will give you the private SSH key
 that you need to download to your machine.
 
 <p align="center">
-    <img width="700" src="ttps://github.com/user-attachments/assets/9dcb27df-941e-4e7d-8b3f-bb22ac349bd4">
+    <img width="700" src="https://github.com/user-attachments/assets/9dcb27df-941e-4e7d-8b3f-bb22ac349bd4">
 </p>
 
 After this,


### PR DESCRIPTION
closes #9 

This adds documentation to create a VM on Azure, setting up SSH access for both Windows and Linux servers, and installing and deploying `Plausible` to it, so it is accessible on `HTTPS`.

The server I tested on is down to save costs.